### PR TITLE
Fixed rare Window bug in EditorFacebookMockDialog

### DIFF
--- a/Facebook.Unity/PlatformEditor/EditorFacebookMockDialog.cs
+++ b/Facebook.Unity/PlatformEditor/EditorFacebookMockDialog.cs
@@ -46,7 +46,7 @@ namespace Facebook.Unity.Editor
 
         public void OnGUI()
         {
-            GUI.ModalWindow(
+            GUI.Window(
                 this.GetHashCode(),
                 this.modalRect,
                 this.OnGUIDialog,


### PR DESCRIPTION
This is a fix for the rare case when using the GUI.ModalWindow causes exceptions when interacted with EditorFacebookMockDialog.
Changing the GUI.ModalWindow to GUI.Window fixes the issue and causes no behavioral changes.